### PR TITLE
Fix import paths and reduce proof size

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 # The import path is where your repository can be found.
 # To import subpackages, always prepend the full import path.
 # If you change this, run `make clean`. Read more: https://git.io/vM7zV
-IMPORT_PATH := github.com/cloudflare/btd
+IMPORT_PATH := github.com/privacypass/challenge-bypass-server
 
 # V := 1 # When V is set, print commands and build progress.
 

--- a/crypto/dleq.go
+++ b/crypto/dleq.go
@@ -40,8 +40,6 @@ type Proof struct {
 }
 
 type Base64Proof struct {
-	G, M string
-	H, Z string
 	R    string
 	C    string
 }
@@ -151,10 +149,6 @@ func (pr *Proof) Verify() bool {
 // Base64 encode the fields of the DLEQ proof for sending back to client
 func (pr *Proof) EncodeProof() *Base64Proof {
 	ep := &Base64Proof{}
-	ep.G = b64.StdEncoding.EncodeToString(pr.G.Marshal())
-	ep.H = b64.StdEncoding.EncodeToString(pr.H.Marshal())
-	ep.M = b64.StdEncoding.EncodeToString(pr.M.Marshal())
-	ep.Z = b64.StdEncoding.EncodeToString(pr.Z.Marshal())
 	ep.R = b64.StdEncoding.EncodeToString(pr.R.Bytes())
 	ep.C = b64.StdEncoding.EncodeToString(pr.C.Bytes())
 
@@ -165,28 +159,6 @@ func (pr *Proof) EncodeProof() *Base64Proof {
 func (ep *Base64Proof) DecodeProof(curve elliptic.Curve) (*Proof, error) {
 	pr := &Proof{}
 	var err error
-
-	// Decoded each of the points from b64 to *Point format
-	pr.G, err = decodePoint(curve, ep.G)
-	if err != nil {
-		return nil, err
-	}
-
-	pr.M, err = decodePoint(curve, ep.M)
-	if err != nil {
-		return nil, err
-	}
-
-	pr.H, err = decodePoint(curve, ep.H)
-	if err != nil {
-		return nil, err
-	}
-
-	pr.Z, err = decodePoint(curve, ep.Z)
-	if err != nil {
-		return nil, err
-	}
-
 	// decode big.Int fields
 	RBytes, err := b64.StdEncoding.DecodeString(ep.R)
 	if err != nil {
@@ -201,21 +173,6 @@ func (ep *Base64Proof) DecodeProof(curve elliptic.Curve) (*Proof, error) {
 	pr.C = new(big.Int).SetBytes(CBytes)
 
 	return pr, nil
-}
-
-// Decodes a point from b64 representation
-func decodePoint(curve elliptic.Curve, b64Point string) (*Point, error) {
-	p := &Point{}
-	pBytes, err := b64.StdEncoding.DecodeString(b64Point)
-	if err != nil {
-		return nil, err
-	}
-	err = p.Unmarshal(curve, pBytes)
-	if err != nil {
-		return nil, err
-	}
-
-	return p, nil
 }
 
 // Marshal proof as part of BatchProof objects for responses

--- a/crypto/dleq_test.go
+++ b/crypto/dleq_test.go
@@ -5,9 +5,30 @@ import (
 	"crypto/elliptic"
 	"crypto/rand"
 	_ "crypto/sha256"
+	b64 "encoding/base64"
+	"encoding/json"
 	"math/big"
 	"testing"
 )
+
+func setup(curve elliptic.Curve) ([]byte, *Point, *Point, error) {
+	x, _, _, err := elliptic.GenerateKey(curve, rand.Reader)
+	if err != nil {
+		return nil, nil, nil, err
+	}
+	_, Gx, Gy, err := elliptic.GenerateKey(curve, rand.Reader)
+	G := &Point{Curve: curve, X: Gx, Y: Gy}
+	if err != nil {
+		return nil, nil, nil, err
+	}
+	_, Mx, My, err := elliptic.GenerateKey(curve, rand.Reader)
+	M := &Point{Curve: curve, X: Mx, Y: My}
+	if err != nil {
+		return nil, nil, nil, err
+	}
+
+	return x, G, M, nil
+}
 
 func TestValidProof(t *testing.T) {
 	// All public keys are going to be generators, so GenerateKey is a handy
@@ -15,24 +36,14 @@ func TestValidProof(t *testing.T) {
 	// relationship breaks the token scheme. Ideally the generator points
 	// would come from a group PRF or something like Elligator.
 	curve := elliptic.P256()
-	x, _, _, err := elliptic.GenerateKey(curve, rand.Reader)
-	if err != nil {
-		t.Fatal(err)
-	}
-	_, Gx, Gy, err := elliptic.GenerateKey(curve, rand.Reader)
-	G := &Point{Curve: curve, X: Gx, Y: Gy}
-	if err != nil {
-		t.Fatal(err)
-	}
-	_, Mx, My, err := elliptic.GenerateKey(curve, rand.Reader)
-	M := &Point{Curve: curve, X: Mx, Y: My}
+	x, G, M, err := setup(curve)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	Hx, Hy := curve.ScalarMult(Gx, Gy, x)
+	Hx, Hy := curve.ScalarMult(G.X, G.Y, x)
 	H := &Point{Curve: curve, X: Hx, Y: Hy}
-	Zx, Zy := curve.ScalarMult(Mx, My, x)
+	Zx, Zy := curve.ScalarMult(M.X, M.Y, x)
 	Z := &Point{Curve: curve, X: Zx, Y: Zy}
 
 	proof, err := NewProof(crypto.SHA256, G, H, M, Z, new(big.Int).SetBytes(x))
@@ -42,6 +53,34 @@ func TestValidProof(t *testing.T) {
 	if !proof.Verify() {
 		t.Fatal("proof was invalid")
 	}
+
+	// Marshal Proof
+	prB64, err := proof.Marshal()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Unmarshal proof
+	prBytes, err := b64.StdEncoding.DecodeString(prB64)
+	if err != nil {
+		t.Fatal(err)
+	}
+	ep := &Base64Proof{}
+	json.Unmarshal(prBytes, ep)
+	proofNew, err := ep.DecodeProof(curve)
+	if err != nil {
+		t.Fatal(err)
+	}
+	proofNew.hash = crypto.SHA256
+	proofNew.G = G
+	proofNew.H = H
+	proofNew.M = M
+	proofNew.Z = Z
+
+	// Verify new proof
+	if !proofNew.Verify() {
+		t.Fatal("proof was invalid after marshaling")
+	}
 }
 
 func TestInvalidProof(t *testing.T) {
@@ -50,17 +89,7 @@ func TestInvalidProof(t *testing.T) {
 	// relationship breaks the token scheme. Ideally the generator points
 	// would come from a group PRF or something like Elligator.
 	curve := elliptic.P256()
-	x, _, _, err := elliptic.GenerateKey(curve, rand.Reader)
-	if err != nil {
-		t.Fatal(err)
-	}
-	_, Gx, Gy, err := elliptic.GenerateKey(curve, rand.Reader)
-	G := &Point{Curve: curve, X: Gx, Y: Gy}
-	if err != nil {
-		t.Fatal(err)
-	}
-	_, Mx, My, err := elliptic.GenerateKey(curve, rand.Reader)
-	M := &Point{Curve: curve, X: Mx, Y: My}
+	x, G, M, err := setup(curve)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -70,11 +99,11 @@ func TestInvalidProof(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	Hx, Hy := curve.ScalarMult(Gx, Gy, x)
+	Hx, Hy := curve.ScalarMult(G.X, G.Y, x)
 	H := &Point{Curve: curve, X: Hx, Y: Hy}
 
 	// using Z = nM instead
-	Zx, Zy := curve.ScalarMult(Mx, My, n)
+	Zx, Zy := curve.ScalarMult(M.X, M.Y, n)
 	Z := &Point{Curve: curve, X: Zx, Y: Zy}
 
 	proof, err := NewProof(crypto.SHA256, G, H, M, Z, new(big.Int).SetBytes(x))

--- a/crypto/generate_proof.go
+++ b/crypto/generate_proof.go
@@ -13,7 +13,7 @@ import (
 	"os"
 	"time"
 
-	"github.com/cloudflare/btd/crypto"
+	"github.com/privacypass/challenge-bypass-server/crypto"
 )
 
 func main() {

--- a/format_test.go
+++ b/format_test.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"testing"
 
-	"github.com/cloudflare/btd/crypto"
+	"github.com/privacypass/challenge-bypass-server/crypto"
 )
 
 func TestEncodeTokenArray(t *testing.T) {

--- a/issuer.go
+++ b/issuer.go
@@ -6,10 +6,11 @@ import (
 	"encoding/base64"
 	"errors"
 	"fmt"
-	"github.com/cloudflare/btd/crypto"
-	"github.com/cloudflare/btd/metrics"
 	"math/big"
 	"net"
+
+	"github.com/privacypass/challenge-bypass-server/crypto"
+	"github.com/privacypass/challenge-bypass-server/metrics"
 )
 
 var (

--- a/server/main.go
+++ b/server/main.go
@@ -13,9 +13,9 @@ import (
 	"os"
 	"time"
 
-	"github.com/cloudflare/btd"
-	"github.com/cloudflare/btd/crypto"
-	"github.com/cloudflare/btd/metrics"
+	"github.com/privacypass/challenge-bypass-server"
+	"github.com/privacypass/challenge-bypass-server/crypto"
+	"github.com/privacypass/challenge-bypass-server/metrics"
 )
 
 var (


### PR DESCRIPTION
- fix issue #1 
- Make DLEQ proofs smaller
-- Only send back values that are necessary for verification (e.g. R,C)
-- Compatible with most recent version of extension
