### PR TITLE
Fix json.Unmarshal as a pointer should be passed to it

### DIFF
--- a/crypto/curve.go
+++ b/crypto/curve.go
@@ -39,11 +39,11 @@ func (p *Point) MarshalJSON() ([]byte, error) {
 
 func (p *Point) UnmarshalJSON(data []byte) error {
 	var byteRepr []byte
-	err := json.Unmarshal(data, byteRepr)
+	err := json.Unmarshal(data, &byteRepr)
 	if err != nil {
 		return err
 	}
-	return p.Unmarshal(p.Curve, data)
+	return p.Unmarshal(p.Curve, byteRepr)
 }
 
 // Marshal calls through to elliptic.Marshal using the Curve field of the

--- a/crypto/curve_test.go
+++ b/crypto/curve_test.go
@@ -8,6 +8,27 @@ import (
 	"testing"
 )
 
+func TestMarshalAndUnmarshalJSONP256(t *testing.T) {
+	curve := elliptic.P256()
+	_, x, y, err := elliptic.GenerateKey(curve, rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	P := &Point{Curve: curve, X: x, Y: y}
+	uBytes, err := P.MarshalJSON()
+	if err != nil {
+		t.Fatal(err)
+	}
+	Q := &Point{Curve: curve, X: nil, Y: nil}
+	err = Q.UnmarshalJSON(uBytes)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if P.X.Cmp(Q.X) != 0 || P.Y.Cmp(Q.Y) != 0 {
+		t.Fatal("point came back different")
+	}
+}
+
 func TestUncompressedRoundTripP256(t *testing.T) {
 	curve := elliptic.P256()
 	_, x, y, err := elliptic.GenerateKey(curve, rand.Reader)
@@ -17,7 +38,10 @@ func TestUncompressedRoundTripP256(t *testing.T) {
 	P := &Point{Curve: curve, X: x, Y: y}
 	uBytes := P.Marshal()
 	Q := &Point{Curve: curve, X: nil, Y: nil}
-	Q.Unmarshal(curve, uBytes)
+	err = Q.Unmarshal(curve, uBytes)
+	if err != nil {
+		t.Fatal(err)
+	}
 	if P.X.Cmp(Q.X) != 0 || P.Y.Cmp(Q.Y) != 0 {
 		t.Fatal("point came back different")
 	}

--- a/server/main.go
+++ b/server/main.go
@@ -62,7 +62,7 @@ func loadConfigFile(filePath string) (Server, error) {
 	if err != nil {
 		return conf, err
 	}
-	err = json.Unmarshal(data, conf)
+	err = json.Unmarshal(data, &conf)
 	if err != nil {
 		return conf, err
 	}


### PR DESCRIPTION
This fixes the usage of `json.Unmarshal` as the second argument to it should be a pointer, see: https://github.com/golang/go/issues/27564, and also the documentation: "Marshal traverses the value v recursively. If an encountered value implements the Marshaler interface and is not a nil pointer (...)" (https://golang.org/pkg/encoding/json/#Marshal). If a pointer is not used, a runtime error is shown.

This also adds a test and fixes the `UnmarshalJSON` function on the crypto folder as it was using the wrong value as input to the inside call. 